### PR TITLE
feat: 适配discord协议

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ _✨ splatoon3游戏日程查询插件 ✨_
 <a href="https://github.com/nonebot/adapter-qq">
 <img src="https://img.shields.io/badge/QQ-Adapter-lightgrey?style=social" alt="QQ">
 </a>
+<a href="https://github.com/nonebot/adapter-discord">
+<img src="https://img.shields.io/badge/discord-Adapter-lightgrey?style=social&logo=discord" alt="discord">
+</a>
 </p>
 
 </div>
@@ -44,7 +47,7 @@ _✨ splatoon3游戏日程查询插件 ✨_
 
 ## 📖 介绍
 
-- 一个基于nonebot2框架的splatoon3游戏日程查询插件,支持onebot11,onebot12,[telegram](https://github.com/nonebot/adapter-telegram)协议,[kook](https://github.com/Tian-que/nonebot-adapter-kaiheila)协议,[QQ官方bot](https://github.com/nonebot/adapter-qq)协议
+- 一个基于nonebot2框架的splatoon3游戏日程查询插件,支持onebot11,onebot12,[telegram](https://github.com/nonebot/adapter-telegram)协议,[kook](https://github.com/Tian-que/nonebot-adapter-kaiheila)协议,[QQ官方bot](https://github.com/nonebot/adapter-qq)协议,[discord](https://github.com/nonebot/adapter-discord)协议
 - 全部查询图片,全部采用pillow精心绘制,图片效果可查看下面的[效果图](#效果图)
 - 建议配合我做的[nso查询插件](https://github.com/Cypas/splatoon3-nso)一起使用
 

--- a/nonebot_plugin_splatoon3_schedule/__init__.py
+++ b/nonebot_plugin_splatoon3_schedule/__init__.py
@@ -30,7 +30,7 @@ __plugin_meta__ = PluginMetadata(
     homepage="https://github.com/Cypas/splatoon3-schedule",
     # 发布必填。
     config=Config,
-    supported_adapters={"~onebot.v11", "~onebot.v12", "~telegram", "~kaiheila", "~qq"},
+    supported_adapters={"~onebot.v11", "~onebot.v12", "~telegram", "~kaiheila", "~qq", "~discord"},
 )
 
 # 图 触发器  正则内需要涵盖所有的同义词

--- a/nonebot_plugin_splatoon3_schedule/check.py
+++ b/nonebot_plugin_splatoon3_schedule/check.py
@@ -257,9 +257,11 @@ async def _permission_check(bot: Bot, event: Event, matcher: Matcher, state: T_S
     uid = event.get_user_id()
     state["_uid_"] = uid or default_id
 
-    if isinstance(event, (V11_PME, V12_PME, Tg_PME, Kook_PME, QQ_PME, QQ_C2CME)):
+    if isinstance(
+        event, (V11_PME, V12_PME, Tg_PME, Kook_PME, QQ_PME, QQ_C2CME, Dc_PME)
+    ):
         # 频道私聊
-        if isinstance(event, (V11_PME, V12_PME, Tg_PME, Kook_PME, QQ_PME)):
+        if isinstance(event, (V11_PME, V12_PME, Tg_PME, Kook_PME, QQ_PME, Dc_PME)):
             state["_msg_source_type_"] = "private"
             rule = plugin_config.splatoon3_permit_private
         # qq c2c私聊
@@ -311,7 +313,7 @@ async def _permission_check(bot: Bot, event: Event, matcher: Matcher, state: T_S
             )
             await matcher.finish()
     # 服务器频道
-    elif isinstance(event, (V12_CME, Kook_CME, QQ_CME)):
+    elif isinstance(event, (V12_CME, Kook_CME, QQ_CME, Dc_GME)):
         state["_msg_source_type_"] = "channel"
         if plugin_config.splatoon3_permit_channel:
             if isinstance(event, V12_CME):
@@ -321,6 +323,9 @@ async def _permission_check(bot: Bot, event: Event, matcher: Matcher, state: T_S
                 guid = event.extra.guild_id
                 cid = event.group_id
             elif isinstance(event, QQ_CME):
+                guid = event.guild_id
+                cid = event.channel_id
+            elif isinstance(event, Dc_GME):
                 guid = event.guild_id
                 cid = event.channel_id
             state["_guid_"] = guid

--- a/nonebot_plugin_splatoon3_schedule/util.py
+++ b/nonebot_plugin_splatoon3_schedule/util.py
@@ -151,6 +151,10 @@ async def send_msg(
                     pass
                 else:
                     logger.warning(f"QQ send msg error: {e}")
+        elif isinstance(bot, Dc_Bot):
+            await bot.send(
+                event, message=Dc_MsgSeg.text(msg), reply_message=reply_mode
+            )
 
     elif isinstance(msg, bytes):
         # 图片
@@ -210,6 +214,12 @@ async def send_msg(
                     await bot.send(event, message=QQ_MsgSeg.image(url))
                 else:
                     logger.warning(f"QQ send msg error: {e}")
+        elif isinstance(bot, Dc_Bot):
+            await bot.send(
+                event,
+                message=Dc_MsgSeg.attachment(file="temp.png", content=img),
+                reply_message=reply_mode,
+            )
 
     if not is_ad and trigger_with_probability():
         if isinstance(bot, QQ_Bot):
@@ -267,6 +277,8 @@ async def send_channel_msg(bot: Bot, source_id, msg: str | bytes):
                 logger.warning(f"主动消息发送失败，api操作结果为{e.__dict__}")
         elif isinstance(bot, Tg_Bot):
             await bot.send_message(chat_id=source_id, text=msg)
+        elif isinstance(bot, Dc_Bot):
+            await bot.send_to(channel_id=source_id, message=Dc_MsgSeg.text(msg))
     elif isinstance(msg, bytes):
         # 图片
         img = msg
@@ -286,6 +298,11 @@ async def send_channel_msg(bot: Bot, source_id, msg: str | bytes):
                 logger.warning(f"主动消息发送失败，api操作结果为{e.__dict__}")
         elif isinstance(bot, Tg_Bot):
             await bot.send_photo(source_id, img)
+        elif isinstance(bot, Dc_Bot):
+            await bot.send_to(
+                channel_id=source_id,
+                message=Dc_MsgSeg.attachment(file="temp.png", content=img),
+            )
 
 
 async def send_private_msg(bot: Bot, source_id, msg: str | bytes, event=None):
@@ -306,6 +323,9 @@ async def send_private_msg(bot: Bot, source_id, msg: str | bytes, event=None):
                 logger.warning(f"主动消息发送失败，api操作结果为{e.__dict__}")
         elif isinstance(bot, Tg_Bot):
             await bot.send_message(chat_id=source_id, text=msg)
+        elif isinstance(bot, Dc_Bot):
+            channel = await bot.create_DM(recipient_id=source_id)
+            await bot.send_to(channel_id=channel.id, message=Dc_MsgSeg.text(msg))
 
     elif isinstance(msg, bytes):
         # 图片
@@ -328,6 +348,12 @@ async def send_private_msg(bot: Bot, source_id, msg: str | bytes, event=None):
                 logger.warning(f"主动消息发送失败，api操作结果为{e.__dict__}")
         elif isinstance(bot, Tg_Bot):
             await bot.send_photo(source_id, img)
+        elif isinstance(bot, Dc_Bot):
+            channel = await bot.create_DM(recipient_id=source_id)
+            await bot.send_to(
+                channel_id=channel.id,
+                message=Dc_MsgSeg.attachment(file="temp.png", content=img),
+            )
 
 
 async def get_qq_md(user_id: str, img_size: tuple[int, int], url: str) -> QQ_Msg:

--- a/nonebot_plugin_splatoon3_schedule/utils/bot.py
+++ b/nonebot_plugin_splatoon3_schedule/utils/bot.py
@@ -54,3 +54,11 @@ from nonebot.adapters.qq.event import GroupMessageCreateEvent as QQ_GME  # 群�
 from nonebot.adapters.qq.event import C2CMessageCreateEvent as QQ_C2CME  # Q私聊信息
 from nonebot.adapters.qq.event import DirectMessageCreateEvent as QQ_PME  # 频道私聊信息
 from nonebot.adapters.qq.event import AtMessageCreateEvent as QQ_CME  # 频道艾特信息
+
+# discord协议
+from nonebot.adapters.discord import Bot as Dc_Bot
+from nonebot.adapters.discord import Message as Dc_Msg
+from nonebot.adapters.discord import MessageSegment as Dc_MsgSeg
+from nonebot.adapters.discord import MessageEvent as Dc_ME
+from nonebot.adapters.discord import DirectMessageCreateEvent as Dc_PME  # 私信
+from nonebot.adapters.discord import GuildMessageCreateEvent as Dc_GME  # 服务器频道消息

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "nonebot-adapter-telegram>=0.1.0b20,<0.2",
     "nonebot-adapter-kaiheila>=0.3.4,<0.4",
     "nonebot-adapter-qq>=1.7.1,<2",
+    "nonebot-adapter-discord>=1.1.9,<2",
     "nonebot-plugin-apscheduler>=0.5.0,<0.6",
     "nonebot_plugin_datastore>=1.3.0,<2",
     "cos_python_sdk_v5>=1.9.30,<2",


### PR DESCRIPTION
适配了 discord 协议，基于官方 [nonebot-adapter-discord](https://github.com/nonebot/adapter-discord)，其他平台逻辑没有改动。

- utils/bot.py 引入 discord 的 Bot/消息/事件别名
- check.py 权限检查加入 discord 的私聊/频道事件分支
- util.py 的 send_msg / send_channel_msg / send_private_msg 加 discord 分支，图片用 attachment(content=bytes) 直接发字节不用落盘，主动私信按 discord 的要求先 create_DM 拿频道再发
- supported_adapters 加 ~discord，pyproject 加 nonebot-adapter-discord>=1.1.9,<2
- README 补了 discord 说明

自己搭了个 discord bot 常驻部署验证过，频道里发「图」等指令正常返回渲染图，其余指令和私聊场景用构造事件的方式回归验证，都能正常出图。

配套的 nso 适配：https://github.com/Cypas/splatoon3-nso/pull/111
